### PR TITLE
Allow NaN point cloud values when necessary

### DIFF
--- a/rosboard/compression.py
+++ b/rosboard/compression.py
@@ -264,7 +264,13 @@ def compress_point_cloud2(msg, output):
         decode_fields = ("x", "y")
     
     try:
+        # Try to decode the point cloud by first skipping points with NaN values
+        # If every point in a field has NaN values, then continue with what is there
         points = decode_pcl2(msg, field_names = decode_fields, skip_nans = True)
+
+        if len(points) == 0:
+            points = decode_pcl2(msg, field_names = decode_fields, skip_nans = False)
+
     except AssertionError as e:
         output["_error"] = "PointCloud2 error: %s" % str(e)
     


### PR DESCRIPTION
The traversability map topic caused a crash in rosboard. This is due to the fact that rosboard, by default, would filter out points with NaN values when compressing the message. This resulted in some internal fields being empty, which caused rosboard to fail when trying to perform operations on an empty array.

To resolve this, I made a small change to skip NaN values when initially trying to compress the message. If the resulting array is empty, it will then try to compress again, this time including points that have NaN values. This way we can maximize the number of "good" points in the display when downsampling, but still provide a backup option of just displaying whatever it's fed, if needed.