### PR TITLE
Hides the warning for large point clouds

### DIFF
--- a/rosboard/html/js/viewers/meta/Viewer.js
+++ b/rosboard/html/js/viewers/meta/Viewer.js
@@ -131,7 +131,7 @@ class Viewer {
     }
 
     if(data._warn) {
-      this.warn(data._warn);
+      // this.warn(data._warn);
     }
 
     // actually update the data

--- a/rosboard/html/js/viewers/meta/Viewer.js
+++ b/rosboard/html/js/viewers/meta/Viewer.js
@@ -131,7 +131,7 @@ class Viewer {
     }
 
     if(data._warn) {
-      // this.warn(data._warn);
+      console.debug("Rosboard warning: Point cloud has reached threshold of 65,535 points")
     }
 
     // actually update the data


### PR DESCRIPTION
When point clouds were above 65,536 points a popup would appear, blocking the rosboard viewer. This hides that popup

Jira issue: https://offworld-ai.atlassian.net/browse/AAGSB-2115?atlOrigin=eyJpIjoiZDVkYzQ1MDhkMWJiNDlhNDk5MzgyZGFjMDlhYjBiYzAiLCJwIjoiaiJ9