### PR TITLE
Remove the rosboard warning that a topic is not found to avoid spam

### DIFF
--- a/rosboard/rosboard.py
+++ b/rosboard/rosboard.py
@@ -7,9 +7,10 @@ import threading
 import time
 import tornado, tornado.web, tornado.websocket
 import traceback
+from bot_settings import Settings
 
 if os.environ.get("ROS_VERSION") == "1":
-    import rospy # ROS1
+    import rospy # ROS1_top
 elif os.environ.get("ROS_VERSION") == "2":
     import rosboard.rospy2 as rospy # ROS2
 else:
@@ -194,6 +195,11 @@ class ROSBoardNode(object):
                     if topic_name not in self.local_subs:
                         rospy.loginfo("Subscribing to _top [non-ros]")
                         self.local_subs[topic_name] = ProcessesSubscriber(self.on_top)
+                    continue
+
+                # check if remote sub request is not actually a ROS topic before proceeding
+                if Settings.get('debug_mode') and topic_name not in self.all_topics:
+                    rospy.logwarn("warning: topic %s not found" % topic_name)
                     continue
 
                 # if the local subscriber doesn't exist for the remote sub, create it

--- a/rosboard/rosboard.py
+++ b/rosboard/rosboard.py
@@ -196,11 +196,6 @@ class ROSBoardNode(object):
                         self.local_subs[topic_name] = ProcessesSubscriber(self.on_top)
                     continue
 
-                # check if remote sub request is not actually a ROS topic before proceeding
-                if topic_name not in self.all_topics:
-                    rospy.logwarn("warning: topic %s not found" % topic_name)
-                    continue
-
                 # if the local subscriber doesn't exist for the remote sub, create it
                 if topic_name not in self.local_subs:
                     topic_type = self.all_topics[topic_name]


### PR DESCRIPTION
Rosboard spams the console logs when a topic its trying to connect to has no data. This isn't really useful for our custom rosboard viewer. and some team members have complained about the spam in the core docker, ~~so I just removed the error message~~ the error will display if `debug_mode` is enabled in `settings.yaml`. 

https://offworld-ai.atlassian.net/browse/AAGSB-2175?atlOrigin=eyJpIjoiMDg3Nzg0NTQyNjI4NDExMmJjY2FlMjdjMzllZmUyODQiLCJwIjoiaiJ9