### PR TITLE
AAGSB-1737 added invert query parameter to stream viewer URL

### DIFF
--- a/rosboard/html/js/viewer.js
+++ b/rosboard/html/js/viewer.js
@@ -66,7 +66,8 @@ function newCard() {
 let onOpen = function() {
   for(let topic_name in subscriptions) {
     console.log("Re-subscribing to " + topic_name);
-    initSubscribe({topicName: topic_name, topicType: subscriptions[topic_name].topicType, rate: subscriptions[topic_name].rate});
+    initSubscribe({topicName: topic_name, topicType: subscriptions[topic_name].topicType,
+      rate: subscriptions[topic_name].rate, invert: subscriptions[topic_name].invert});
   }
 }
 
@@ -94,7 +95,7 @@ let onTopics = function(topics) {
   // do nothing here in viewer only mode
 }
 
-function initSubscribe({topicName, topicType, rate}) {
+function initSubscribe({topicName, topicType, rate, invert}) {
   // creates a subscriber for topicName
   // and also initializes a viewer (if it doesn't already exist)
   // in advance of arrival of the first data
@@ -102,7 +103,8 @@ function initSubscribe({topicName, topicType, rate}) {
   if(!subscriptions[topicName]) {
     subscriptions[topicName] = {
       topicType: topicType,
-      rate: rate
+      rate: rate,
+      invert: invert
     }
   }  
   currentTransport.subscribe({topicName: topicName, maxUpdateRate: rate});
@@ -110,7 +112,7 @@ function initSubscribe({topicName, topicType, rate}) {
     let card = newCard();
     let viewer = Viewer.getDefaultViewerForType(topicType);
     try {
-      subscriptions[topicName].viewer = new viewer(card, topicName, topicType, false);
+      subscriptions[topicName].viewer = new viewer(card, topicName, topicType, invert, false);
     } catch(e) {
       console.log(e);
       card.remove();
@@ -142,7 +144,8 @@ $(() => {
     const topic = urlParams.get('topic');
     const type = urlParams.get('type');
     const rate = urlParams.get('rate');
-    initSubscribe({topicName: topic, topicType: type, rate: rate});
+    const invert = urlParams.has('invert');
+    initSubscribe({topicName: topic, topicType: type, rate: rate, invert: invert});
   }
 });
 

--- a/rosboard/html/js/viewers/ImageViewer.js
+++ b/rosboard/html/js/viewers/ImageViewer.js
@@ -10,8 +10,16 @@ class ImageViewer extends Viewer {
       .css({'font-size': '11pt'})
       .appendTo(this.card.content);
 
+    var rotation;
+    if (this.invert) {
+      rotation = "rotate(180deg)";
+    } else {
+      rotation = "rotate(0deg)";
+    }
+
     this.img = $('<img></img>')
-      .css({"width": "100%"})
+      .css({"width": "100%",
+      "transform": rotation})
       .appendTo(this.viewerNode);
 
     let that = this;

--- a/rosboard/html/js/viewers/meta/Space2DViewer.js
+++ b/rosboard/html/js/viewers/meta/Space2DViewer.js
@@ -228,6 +228,10 @@ class Space2DViewer extends Viewer {
   }
 
   draw(drawObjects) {
+    if (this.invert) {
+      console.warn("Invert not yet implemented for Space2DViewer.  Ignoring.");
+    }
+
     // converts x in meters to pixel-wise x based on current bounds
     let x2px = (x) => Math.floor(this.size * ((x - this.xmin) / (this.xmax - this.xmin)));
     // converts y in meters to pixel-wise y based on current bounds

--- a/rosboard/html/js/viewers/meta/Space3DViewer.js
+++ b/rosboard/html/js/viewers/meta/Space3DViewer.js
@@ -40,7 +40,7 @@ class Space3DViewer extends Viewer {
     $(this.gl.canvas).css("width", "100%");
 	  this.gl.animate(); // launch loop
 
-		this.cam_pos = [0,100,100];
+	this.cam_pos = [0,100,100];
     this.cam_theta = -1.5707;
     this.cam_phi = 1.0;
     this.cam_r = 50.0;
@@ -56,7 +56,7 @@ class Space3DViewer extends Viewer {
     this.model = mat4.create();
     this.mvp = mat4.create();
     this.temp = mat4.create();
-
+    
     this.gl.captureMouse(true, true);
 		this.gl.onmouse = function(e) {
 			if(e.dragging) {
@@ -98,7 +98,17 @@ class Space3DViewer extends Viewer {
       that.view = mat4.create();
       mat4.perspective(that.proj, 45 * DEG2RAD, that.gl.canvas.width / that.gl.canvas.height, 0.1, 1000);
       mat4.lookAt(that.view, that.cam_pos, [this.cam_offset_x,this.cam_offset_y, this.cam_offset_z], [0,0,1]);
-	    mat4.multiply(that.mvp, that.proj, that.view);
+	  mat4.multiply(that.mvp, that.proj, that.view);
+      if (that.invert) {
+        var old_mvp = mat4.clone(that.mvp);
+        var invert_mat4 = mat4.fromValues(
+          -1.0,  0.0,  0.0,  0.0,
+           0.0,  1.0,  0.0,  0.0,
+           0.0,  0.0, -1.0,  0.0,
+           0.0,  0.0,  0.0,  1.0
+        );
+        mat4.multiply(that.mvp, old_mvp, invert_mat4);
+      }
     }
 
     this.updatePerspective();

--- a/rosboard/html/js/viewers/meta/Viewer.js
+++ b/rosboard/html/js/viewers/meta/Viewer.js
@@ -11,10 +11,11 @@ class Viewer {
     * Class constructor.
     * @constructor
   **/
-  constructor(card, topicName, topicType, header) {
+  constructor(card, topicName, topicType, invert, header) {
     this.card = card;
     this.isPaused = false;
     this.header = header !== undefined ? header : true;
+    this.invert = invert !== undefined ? invert : false;
 
     this.topicName = topicName;
     this.topicType = topicType;


### PR DESCRIPTION
## Link to Jira Issue

[AAGSB-1737](https://offworld-ai.atlassian.net/browse/AAGSB-1737)

## Changes

* Added `invert` query parameter to rosboard stream viewer URL
* Added the following functionality when `&invert` is appended to the stream viewer URL:
  * `Space3DViewer`: rotate data, grid, and coordinate axes 180 degrees about the sensor/world y-axis
  * `ImageViewer`: rotate image by 180 degrees

## Testing

* `Space3DViewer`
  * Played ros2 bag file with `sensor_msgs/msg/PointCloud2` topic data published
  * Opened browser tab to view data published on the topic
    * Without `&invert` - _data is plotted as in the nominal case; no rotation applied_
![Screenshot from 2023-01-26 15-07-39](https://user-images.githubusercontent.com/20928867/214991969-7de215de-d369-4f70-91ec-f0d5a31a6fca.png)
    * With `&invert` - _data is plotted rotated about the y-axis; note the flipping of the x- and z-axes of the drawn coordinate frame_
![Screenshot from 2023-01-26 15-07-11](https://user-images.githubusercontent.com/20928867/214991880-eb41d100-3309-4b0d-94a3-27d91ed7027e.png)     
* `ImageViewer`
  * Launched an ecam streaming instance using the `ecam_v4l2` package with a camera plugged in
  * Opened browser tab to view data published on the topic 
    * Without `&invert` - _image is drawn as it nominally would be_
![Screenshot from 2023-01-26 15-04-19](https://user-images.githubusercontent.com/20928867/214992264-5577ad1d-f2ed-4cfe-af9e-63d85262c93a.png)
    * With `&invert` - _image is flipped, as expected_
![Screenshot from 2023-01-26 15-04-50](https://user-images.githubusercontent.com/20928867/214992282-0c297857-4d9a-4a8c-825b-e56fe9a2e56b.png)

[AAGSB-1737]: https://offworld-ai.atlassian.net/browse/AAGSB-1737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ