### PR TITLE
Save latest pointcloud message in sessionStorage

### DIFF
--- a/rosboard/html/js/viewers/WaypointPointCloudViewer.js
+++ b/rosboard/html/js/viewers/WaypointPointCloudViewer.js
@@ -131,6 +131,10 @@ class WaypointPointCloudViewer extends Viewer {
         document.addEventListener('mouseup', onMouseUp);
         $(this.renderer.domElement).appendTo(this.card.content);
         animate();
+
+        if(sessionStorage.getItem("lastPclMsg")) {
+            this.onData(JSON.parse(sessionStorage.getItem("lastPclMsg")));
+        }
     }
 
     updateBotPosition(botName, msg) {
@@ -160,6 +164,7 @@ class WaypointPointCloudViewer extends Viewer {
             this.updateBotPosition("surveyor", msg.surveyor);
             this.updateBotPosition("digger", msg.digger);
         } else if (msg.__comp) {
+            sessionStorage.setItem("lastPclMsg", JSON.stringify(msg));
             this.mapFrame = msg.header.frame_id;
             this.decodeAndRenderCompressed(msg);
         } else {


### PR DESCRIPTION
https://offworld-ai.atlassian.net/browse/SWTP-1705

Currently, the map viewer waits for a new ROS message to come in before displaying the pointcloud. This PR saves the last pointcloud message in the browser tab and loads that when you refresh the page. Once a new message comes in it will show that instead, but this is nice because you have some visual for the first 5-10 seconds before the next pointcloud message comes in.